### PR TITLE
Make entire lib const

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@
     clippy::must_use_candidate,
     clippy::unreadable_literal
 )]
-#![feature(const_ptr_offset)]
 #![feature(const_slice_from_raw_parts)]
 #![feature(const_mut_refs)]
 #![feature(const_intrinsic_copy)]

--- a/src/udiv128.rs
+++ b/src/udiv128.rs
@@ -1,6 +1,6 @@
 /// Multiply unsigned 128 bit integers, return upper 128 bits of the result
 #[inline]
-fn u128_mulhi(x: u128, y: u128) -> u128 {
+const fn u128_mulhi(x: u128, y: u128) -> u128 {
     let x_lo = x as u64;
     let x_hi = (x >> 64) as u64;
     let y_lo = y as u64;
@@ -26,7 +26,7 @@ fn u128_mulhi(x: u128, y: u128) -> u128 {
 ///   Implementation, 1994, pp. 61–72
 ///
 #[inline]
-pub fn udivmod_1e19(n: u128) -> (u128, u64) {
+pub const fn udivmod_1e19(n: u128) -> (u128, u64) {
     let d = 10_000_000_000_000_000_000_u64; // 10^19
 
     let quot = if n < 1 << 83 {
@@ -36,8 +36,8 @@ pub fn udivmod_1e19(n: u128) -> (u128, u64) {
     };
 
     let rem = (n - quot * d as u128) as u64;
-    debug_assert_eq!(quot, n / d as u128);
-    debug_assert_eq!(rem as u128, n % d as u128);
+    debug_assert!(quot == n / d as u128);
+    debug_assert!(rem as u128 == n % d as u128);
 
     (quot, rem)
 }


### PR DESCRIPTION
This clearly isn't in a mergeable state since it uses unstable features, but I thought I'd put this PR out there so people can use it on nightly. Once all these features are stabilized, it should be a quick merge.

Constification made it possible to write a compile time num cache that's shipped with the binary: https://github.com/SUPERCILEX/ftzz/commit/debcf24b5a701d0434ce3953a2f2bdb15239c2a0.