### PR TITLE
Add CIFuzz Github action

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'itoa'
+        dry-run: false
+        language: rust
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'itoa'
+        fuzz-seconds: 300
+        dry-run: false
+        language: rust
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Add [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) workflow action to have fuzzers build and run on each PR. This is a service offered by OSS-Fuzz where itoa already runs. In the current PR the fuzzers gets build on a pull request and will run for 300 seconds.

I noticed the CI already has a fuzz action so this is an alternative suggestion in case you're interested -- CIFuzz has a set of features that are useful e.g. only highlighting issues only if they are introduced by the given PR, using of OSS-Fuzz code corpus and more. Let me know what you think!

Signed-off-by: David Korczynski <david@adalogics.com>