### PR TITLE
Clarify platform sensitivity of MAX_STR_LEN

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl Buffer {
 /// This trait is sealed and cannot be implemented for types outside of itoa.
 pub trait Integer: private::Sealed {
     /// The maximum length of string that formatting an integer of this type can
-    /// produce.
+    /// produce on the current target platform.
     const MAX_STR_LEN: usize;
 }
 


### PR DESCRIPTION
For example `<isize as itoa::Integer>::MAX_STR_LEN` has a different value if `cfg(target_pointer_width = "32")` compared to `cfg(target_pointer_width = "64")`. The MAX_STR_LEN is not the maximum length of string that formatting an isize can produce _in general_. It is specific to the current platform.

#45