### PR TITLE
Try to prevent Integer<Buffer = …> IDE suggestion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,9 @@ pub trait Integer: private::Sealed {
 
 // Seal to prevent downstream implementations of the Integer trait.
 mod private {
+    #[doc(hidden)]
     pub trait Sealed: Copy {
+        #[doc(hidden)]
         type Buffer: 'static;
         fn write(self, buf: &mut Self::Buffer) -> &str;
     }


### PR DESCRIPTION
Rust-analyzer makes this inappropriate suggestion, even with `hidden`. I didn't find a way to work around it. But with this associated type being `hidden`, maybe this can be reported as a rust-analyzer bug.

![Screenshot from 2024-11-25 11-20-21](https://github.com/user-attachments/assets/373b4313-156d-4b95-9b9a-eeb241964e93)
