### PR TITLE
Optimize 128-bit integer formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,7 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
     let mut remain = n;
 
     // Format per four digits from the lookup table.
-    for quad_index in (0..4).rev() {
+    for quad_index in (1..4).rev() {
         // pull two pairs
         let quad = remain % 1_00_00;
         remain /= 1_00_00;
@@ -425,6 +425,15 @@ fn enc_16lsd<const OFFSET: usize>(buf: &mut [MaybeUninit<u8>], n: u64) {
             buf[quad_index * 4 + OFFSET + 3]
                 .write(*DECIMAL_PAIRS.0.get_unchecked(pair2 as usize * 2 + 1));
         }
+    }
+
+    // final two pairs
+    let (pair1, pair2) = divmod100(remain as u32);
+    unsafe {
+        buf[OFFSET + 0].write(*DECIMAL_PAIRS.0.get_unchecked(pair1 as usize * 2 + 0));
+        buf[OFFSET + 1].write(*DECIMAL_PAIRS.0.get_unchecked(pair1 as usize * 2 + 1));
+        buf[OFFSET + 2].write(*DECIMAL_PAIRS.0.get_unchecked(pair2 as usize * 2 + 0));
+        buf[OFFSET + 3].write(*DECIMAL_PAIRS.0.get_unchecked(pair2 as usize * 2 + 1));
     }
 }
 


### PR DESCRIPTION
The compiler is unaware of the restricted range of the input, so it is unable to optimize out the final division and modulus. By doing this manually, we get a nontrivial performance gain.

By running the included benchmark (`u128[max]/itoa`) repeatedly, I see an improvement from 32.274 ns to 30.470 ns — a 5.6% gain.